### PR TITLE
fix working directory alteration

### DIFF
--- a/py_vncorenlp/vncorenlp.py
+++ b/py_vncorenlp/vncorenlp.py
@@ -58,6 +58,7 @@ class VnCoreNLP:
             self.annotators.append("wseg")
 
         self.model = javaclass_vncorenlp(annotators)
+        os.chdir(self.current_working_dir)
 
     def annotate_text(self, text):
         from jnius import autoclass
@@ -113,7 +114,7 @@ class VnCoreNLP:
             print("")
 
     def annotate_file(self, input_file, output_file):
-        os.chdir(self.current_working_dir)
+        # os.chdir(self.current_working_dir)
         input_str = self.javaclass_String(input_file)
         output_str = self.javaclass_String(output_file)
         self.model.processPipeline(input_str, output_str, self.annotators)


### PR DESCRIPTION
Fix working directory alteration when initializing VnCoreNLP. 

When creating a `VnCoreNLP` instance, the working directory is changed to `save_dir`. After loading the annotation model, I added a line to change it back to `self.current_working_dir`.

I have tried some workaround to avoid changing the working directory, but I finally realized that the Java code of VnCoreNLP load models by related path. So I guess working directory alteration is inevitable now. 
```Java
public class WordSegmenter {
    private  Node root;
    private static WordSegmenter wordSegmenter = null;
    public final static Logger LOGGER = Logger.getLogger(WordSegmenter.class);
    public WordSegmenter()
            throws IOException {
        LOGGER.info("Loading Word Segmentation model");
        String modelPath = System.getProperty("user.dir") + "/models/wordsegmenter/wordsegmenter.rdr";
        if (!new File(modelPath).exists())
            throw new IOException("WordSegmenter: " + modelPath + " is not found!");

        this.constructTreeFromRulesFile(modelPath);
    }
```